### PR TITLE
Build 1.4.0 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "statsforecast" %}
-{% set version = "1.5.0" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3196e52908d8a2439d732dc49f4d3f0ae9c5993be23622ccedd152b1671be802
+  sha256: f468bbd80266601a296a77580521ebfd310a0dbe301153bd170812fce7691740
 
 build:
   skip: true  # [py<37 or s390x]
@@ -31,8 +31,6 @@ requirements:
     - scipy >=1.7.3
     - statsmodels >=0.13.2
     - tqdm
-    - plotly-resampler 
-    - fugue >=0.8.1
 
 test:
   imports:


### PR DESCRIPTION
statsforecast 1.4.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3416](https://anaconda.atlassian.net/browse/PKG-3416)
- [Upstream repository](https://github.com/Nixtla/statsforecast/tree/v1.4.0)
- ~[Upstream changelog/diff]()~

### Explanation of changes:

We have `statsforecast` 1.5 on the snowflake channel but autogluon wants 1.4. It technically works with 1.5, but in practice, it creates conflicts because 1.5 adds a dependency on `fugue` which needs `antlr4-python3-runtime` 4.11 while omegaconf wants `antlr4-python3-runtime` 4.9.

[PKG-3416]: https://anaconda.atlassian.net/browse/PKG-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ